### PR TITLE
Update to UIMA Core 2.10.2

### DIFF
--- a/de.unistuttgart.ims.drama.main/pom.xml
+++ b/de.unistuttgart.ims.drama.main/pom.xml
@@ -112,7 +112,7 @@
 			<plugin>
 				<groupId>org.apache.uima</groupId>
 				<artifactId>jcasgen-maven-plugin</artifactId>
-				<version>2.8.1</version>  <!-- change this to the latest version -->
+				<version>2.10.2</version>  <!-- change this to the latest version -->
 				<executions>
 					<execution>
 						<goals>

--- a/pom.xml
+++ b/pom.xml
@@ -32,6 +32,12 @@
 			<url>https://github.com/nilsreiter</url>
 			<email>nils.reiter@ims.uni-stuttgart.de</email>
 		</developer>
+		<developer>
+			<id>pageljs</id>
+			<name>Janis Pagel</name>
+			<url>https://github.com/pagelj</url>
+			<email>janis.pagel@ims.uni-stuttgart.de</email>
+		</developer>
 	</developers>
 	<properties>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
@@ -116,7 +122,7 @@
 			<dependency>
 				<groupId>org.apache.uima</groupId>
 				<artifactId>uimaj-core</artifactId>
-				<version>2.8.1</version>
+				<version>2.10.2</version>
 			</dependency>
 			<dependency>
 				<groupId>de.unistuttgart.ims</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -132,7 +132,7 @@
 			<dependency>
 				<groupId>commons-io</groupId>
 				<artifactId>commons-io</artifactId>
-				<version>2.5</version>
+				<version>2.6</version>
 			</dependency>
 			<dependency>
 				<groupId>de.tudarmstadt.ukp.dkpro.core</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -127,7 +127,7 @@
 			<dependency>
 				<groupId>de.unistuttgart.ims</groupId>
 				<artifactId>uimautil</artifactId>
-				<version>0.7.2</version>
+				<version>0.7.4</version>
 			</dependency>
 			<dependency>
 				<groupId>commons-io</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -117,7 +117,7 @@
 			<dependency>
 				<groupId>org.apache.uima</groupId>
 				<artifactId>uimafit-core</artifactId>
-				<version>2.2.0</version>
+				<version>2.4.0</version>
 			</dependency>
 			<dependency>
 				<groupId>org.apache.uima</groupId>


### PR DESCRIPTION
# Update UIMA core (2.8.1 &rarr; 2.10.2)

This will fix https://github.com/quadrama/DramaNLP/issues/42 and close https://github.com/quadrama/DramaNLP/issues/43

## Additionally updated:

- uimaFIT (2.2.0 &rarr; 2.4.0)
- uimautil (0.7.2 &rarr; 0.7.4)
- commons-io (2.5 &rarr; 2.6)

## This is also an opportunity to update dkpro from 1.7.0 to 1.9.1

Several issues occurred:

- `PARAM_OVERWRITE = true` needs to be added to all calls of `XmiWriter`
- Import of the POS libraries needs to changed (e.g. `POS_NOUN` instead of `NN`)
- Unresolved issue with `DocumentMetaData`

