### PR TITLE
Set documentId based on source

### DIFF
--- a/de.unistuttgart.ims.drama.api/src/main/resources/dramatypes.xml
+++ b/de.unistuttgart.ims.drama.api/src/main/resources/dramatypes.xml
@@ -153,6 +153,20 @@
 					<description/>
 					<rangeTypeName>uima.cas.Integer</rangeTypeName>
 				</featureDescription>
+				<featureDescription>
+					<name>SourceName</name>
+					<description>Name of the bibliographic source of the document</description>
+					<rangeTypeName>uima.cas.String</rangeTypeName></featureDescription>
+				<featureDescription>
+					<name>TextGridId</name>
+					<description></description>
+					<rangeTypeName>uima.cas.String</rangeTypeName>
+				</featureDescription>
+				<featureDescription>
+					<name>DracorId</name>
+					<description></description>
+					<rangeTypeName>uima.cas.String</rangeTypeName>
+				</featureDescription>
 			</features>
 		</typeDescription>
 		<typeDescription>

--- a/de.unistuttgart.ims.drama.io.core/src/main/java/de/unistuttgart/quadrama/io/core/DramaIOUtil.java
+++ b/de.unistuttgart.ims.drama.io.core/src/main/java/de/unistuttgart/quadrama/io/core/DramaIOUtil.java
@@ -5,11 +5,13 @@ import java.util.HashSet;
 import java.util.Map;
 
 import org.apache.uima.fit.factory.AnnotationFactory;
+import org.apache.uima.fit.util.JCasUtil;
 import org.apache.uima.jcas.JCas;
 import org.apache.uima.jcas.tcas.Annotation;
 import org.jsoup.nodes.Element;
 import org.jsoup.select.Elements;
 
+import de.unistuttgart.ims.drama.api.Drama;
 import de.unistuttgart.ims.uima.io.xml.type.XMLElement;
 import de.unistuttgart.quadrama.io.core.type.HTMLAnnotation;
 
@@ -18,6 +20,13 @@ public class DramaIOUtil {
 	@Deprecated
 	public static void cleanUp(JCas jcas) {
 		jcas.removeAllIncludingSubtypes(HTMLAnnotation.type);
+	}
+	
+	public static void updateDocumentId(JCas jcas) {
+		Drama drama = JCasUtil.selectSingle(jcas, Drama.class);
+		if (drama.getSourceName().equals("TextGrid Repository")) {
+			drama.setDocumentId(drama.getTextGridId());
+		}
 	}
 
 	@Deprecated


### PR DESCRIPTION
If a document comes from TextGrid its Id is the TextGrid Id. However, the default case is now the Dracor Id of the document (in cases when the document comes from different sources than TextGrid, for example Gutenberg)